### PR TITLE
Fix terminating VM detection, navigation issues, and add comprehensive troubleshooting

### DIFF
--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -132,6 +132,8 @@ type VMInfo struct {
 	PrintableStatus            string        `json:"printableStatus"`
 	VMStatusReason             string        `json:"vmStatusReason"`
 	MissingResource            string        `json:"missingResource"`
+	Finalizers                 []string      `json:"finalizers,omitempty"`
+	RemovedPVCs                string        `json:"removedPVCs,omitempty"`
 	Errors                     []VMError     `json:"errors,omitempty"`
 }
 

--- a/internal/services/vmi/vmi.go
+++ b/internal/services/vmi/vmi.go
@@ -203,7 +203,17 @@ func FetchPodNamesForVM(client *kubernetes.Clientset, namespace string, vmName s
 
 	vmPrefix := fmt.Sprintf("virt-launcher-%s-", vmName)
 	for _, pod := range pods.Items {
+		// Check if pod name matches exactly: virt-launcher-{vmName}-{suffix}
+		// The suffix should be exactly 5 random chars, not another VM name
 		if strings.HasPrefix(pod.Name, vmPrefix) {
+			// Extract the suffix after the prefix
+			suffix := strings.TrimPrefix(pod.Name, vmPrefix)
+
+			// Skip if suffix contains additional hyphens (indicates another VM name like "new-xxxxx")
+			if strings.Contains(suffix, "-") {
+				continue
+			}
+
 			nodeName := pod.Spec.NodeName
 			// Find the UID that corresponds to this node
 			for uid, uidNode := range nodeToUID {

--- a/js/renderers/detail-renderer.js
+++ b/js/renderers/detail-renderer.js
@@ -755,6 +755,26 @@ const DetailRenderer = {
                         </div>
                     </div>
                 ` : ''}
+                
+                ${vmData.printableStatus === 'Terminating' && 
+                  (!vmData.vmiInfo || vmData.vmiInfo.length === 0) && 
+                  (!vmData.podInfo || vmData.podInfo.length === 0) ? `
+                    <div class="p-6 border-b border-slate-700">
+                        <div class="p-4 bg-yellow-900/40 border border-yellow-600/50 rounded-lg">
+                            <div class="flex items-center gap-2 mb-2">
+                                <span class="text-yellow-400 text-xl">⚠️</span>
+                                <span class="text-yellow-300 font-semibold text-lg">VM Stuck in Terminating State</span>
+                            </div>
+                            <div class="text-yellow-200 mb-3">
+                                This VM has no active VMI or pods but is stuck terminating. This usually indicates finalizers blocking deletion.
+                            </div>
+                            <button onclick="ViewManager.showAllIssuesView()" 
+                                    class="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded text-sm transition-colors">
+                                View Issue Details & Resolution Steps →
+                            </button>
+                        </div>
+                    </div>
+                ` : ''}
 
                 <div class="p-6">
                     <div class="grid grid-cols-1 xl:grid-cols-2 gap-8">
@@ -762,6 +782,7 @@ const DetailRenderer = {
                         <!-- Left Column: Compute & Migration -->
                         <div class="space-y-6">
                             ${this.renderComputeResources(vmData)}
+                            ${this.renderVMIDetails(vmData)}
                             ${this.renderPodDetails(vmData, splitBrainInfo)}
                             ${this.renderVMErrors(vmData.errors || [])}
                             ${this.renderVolumeAttachment(vmData.attachmentTicketsRaw)}
@@ -1470,6 +1491,52 @@ const DetailRenderer = {
                     
                     <span class="text-slate-400">Node:</span>
                     <span class="text-slate-200 font-mono">${nodeName}</span>
+                </div>
+            </div>
+        `;
+    },
+
+    renderVMIDetails(vmData) {
+        const vmiInfo = vmData.vmiInfo && vmData.vmiInfo.length > 0 ? vmData.vmiInfo[0] : null;
+        
+        if (!vmiInfo) {
+            return `
+                <div class="bg-slate-700/50 border border-slate-600 rounded-lg p-4">
+                    <div class="flex items-center gap-2 mb-4">
+                        <span class="text-lg">🖥️</span>
+                        <h2 class="text-lg font-medium text-white">VMI Information</h2>
+                    </div>
+                    <div class="text-center py-4 text-slate-400">No VMI information available</div>
+                </div>
+            `;
+        }
+
+        return `
+            <div class="bg-slate-700/50 border border-slate-600 rounded-lg p-4">
+                <div class="flex items-center gap-2 mb-4">
+                    <span class="text-lg">🖥️</span>
+                    <h2 class="text-lg font-medium text-white">VMI Information</h2>
+                </div>
+                
+                <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-sm">
+                    <span class="text-slate-400">VMI Name:</span>
+                    <span class="text-white font-mono">${vmiInfo.name || vmData.name}</span>
+                    
+                    <span class="text-slate-400">Phase:</span>
+                    <span class="px-2 py-1 rounded text-xs ${vmiInfo.phase === 'Running' ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'}">${vmiInfo.phase || 'Unknown'}</span>
+                    
+                    <span class="text-slate-400">Node:</span>
+                    <span class="text-slate-200 font-mono">${vmiInfo.nodeName || 'N/A'}</span>
+                    
+                    ${vmiInfo.guestOSInfo && vmiInfo.guestOSInfo.prettyName ? `
+                        <span class="text-slate-400">Guest OS:</span>
+                        <span class="text-slate-200">${vmiInfo.guestOSInfo.prettyName}</span>
+                    ` : ''}
+                    
+                    ${vmiInfo.interfaces && vmiInfo.interfaces.length > 0 ? `
+                        <span class="text-slate-400">IP Address:</span>
+                        <span class="text-slate-200 font-mono">${vmiInfo.interfaces.find(i => i.ipAddress)?.ipAddress || 'N/A'}</span>
+                    ` : ''}
                 </div>
             </div>
         `;


### PR DESCRIPTION


- Fix VM detail navigation to use namespace + name for unique identification
  * Updated click handlers in vm-renderer.js and view-manager.js
  * Fixed search functionality to include namespace in VM selection
  * Updated issue detection to include namespace in all VM-related issues

- Add support for VMs without volumeClaimTemplates annotation
  * ParseVMMetaData now extracts PVC names from volumes array as fallback
  * Fixes VMs like k8s-node03 not appearing in Navigator

- Fix pod name matching to prevent false positives
  * FetchPodNamesForVM now filters out pods with hyphenated suffixes
  * Prevents k8s-node03 from showing k8s-node03-new's pod

- Add stuck terminating VM detection and remediation
  * Backend: Parse finalizers and removedPVCs annotations
  * Frontend: Detect terminating VMs with no VMI/pods and finalizers
  * Severity adjusts based on upgrade status (high if upgrading, medium otherwise)
  * Provides 4-step verification process with kubectl commands
  * Fixed createIssue to preserve custom verification steps

- Improve VMI error messages
  * Terminating VMs: VMI does not exist (VM is terminating) - info level
  * Other VMs: VMI does not exist (VM may not be running) - warning level
  * Better context for actual errors

- Add VMI Information card to VM details page
  * Shows VMI name, phase, node, guest OS, and IP address
  * Positioned between Compute Resources and Pod Information
  * Displays No VMI information available for VMs without VMI

- Add terminating VM banner on detail page
  * Yellow warning banner when VM stuck terminating
  * Links directly to issues page for resolution steps
  * Completes troubleshooting workflow loop